### PR TITLE
Set pre_tax_amount on line items when generating sales invoice

### DIFF
--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -26,7 +26,7 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
       return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
       order.line_items.each do |line_item|
-        line_item.update_column(:pre_tax_amount, line_item.discounted_amount)
+        line_item.update_column(:pre_tax_amount, line_item.discounted_amount.round(2))
       end
 
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)

--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -25,6 +25,10 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
 
       return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
+      order.line_items.each do |line_item|
+        line_item.update_column(:pre_tax_amount, line_item.discounted_amount)
+      end
+
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)
       # run this immediately to ensure that everything matches up before modifying the database
       tax_line_data = SpreeAvatax::SalesShared.build_tax_line_data(order, result)

--- a/spec/models/spree_avatax/sales_invoice_spec.rb
+++ b/spec/models/spree_avatax/sales_invoice_spec.rb
@@ -181,11 +181,33 @@ describe SpreeAvatax::SalesInvoice do
     context 'when an error occurs' do
       let(:error) { StandardError.new('just testing') }
       let!(:gettax_stub) { }
+      let(:order) do
+        create(:order_with_line_items,
+               line_items_count: 2,
+               ship_address: create(:address, {
+                 address1: "1234 Way",
+                 address2: "",
+                 city: "New York",
+                 state: state,
+                 country: country,
+                 zipcode: "10010",
+                 phone: "1111111111",
+               }))
+      end
 
       before do
         expect(SpreeAvatax::SalesShared)
           .to receive(:get_tax)
           .and_raise(error)
+
+        order.line_items.update_all(pre_tax_amount: nil)
+        order.reload
+      end
+
+      it 'sets the pre_tax_amount on each line item in the order' do
+        expect{ subject }.to raise_error(error)
+        expect(order.line_items.first.pre_tax_amount.to_f).to equal(order.line_items.first.discounted_amount.to_f)
+        expect(order.line_items.last.pre_tax_amount.to_f).to equal(order.line_items.last.discounted_amount.to_f)
       end
 
       context 'when an error_handler is not defined' do


### PR DESCRIPTION
If the call to Avatax failed for some reason during SalesInvoice.generate, the order's line items would
be left without a pre_tax_amount. This causes issues when creating reimbursements, as they rely on the
line item's pre tax amount.

This updates the pre_tax_amount on each line item in the order before the call to Avatax is made. This ensures pre_tax_amount will always be available.