### PR TITLE
Add support for --migrate=false

### DIFF
--- a/lib/generators/solidus_avatax/install/install_generator.rb
+++ b/lib/generators/solidus_avatax/install/install_generator.rb
@@ -3,6 +3,11 @@ module SolidusAvatax
     class InstallGenerator < Rails::Generators::Base
 
       class_option :auto_run_migrations, type: :boolean, default: false
+      class_option :migrate, :type => :boolean, :default => true, :banner => 'Run migrations'
+
+      def prepare_options
+        @run_migrations = options[:migrate]
+      end
 
       def self.source_paths
         paths = self.superclass.source_paths
@@ -19,11 +24,14 @@ module SolidusAvatax
       end
 
       def run_migrations
-        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
-        if run_migrations
-          run 'bundle exec rake db:migrate'
-        else
-          puts 'Skipping rake db:migrate, don\'t forget to run it!'
+        if run_migrations= @run_migrations
+          run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
+          if run_migrations
+            run 'bundle exec rake db:migrate'
+          end
+        end
+        if !run_migrations
+          say_status :skipping, "migrations (don't forget to run rake db:migrate)"
         end
       end
     end


### PR DESCRIPTION
If --migrate=false is used, no interactive prompt is shown and
migrations are skipped.

If --migrate=true (the default) is used, the behavior remains
as before, i.e. the interactive prompt is shown unless
:auto_run_migrations = true is specified in the config.