### PR TITLE
Fix test failures due to pre_tax_amount change

### DIFF
--- a/spec/models/spree_avatax/sales_invoice_spec.rb
+++ b/spec/models/spree_avatax/sales_invoice_spec.rb
@@ -200,7 +200,7 @@ describe SpreeAvatax::SalesInvoice do
           .to receive(:get_tax)
           .and_raise(error)
 
-        order.line_items.update_all(pre_tax_amount: nil)
+        order.line_items.update_all(pre_tax_amount: 0)
         order.reload
       end
 


### PR DESCRIPTION
In solidusio/solidus@dcfb791 we backported a change which adds a not
null contstraint to pre_tax_amount. This caused our tests to fail here
because pre_tax_amount was being set to null (just to test that it was
updated).