### PR TITLE
Remove SalesInvoice while clearing tax attributes

### DIFF
--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -47,6 +47,8 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
         end
       end
 
+      SpreeAvatax::SalesShared.update_taxes(order, tax_line_data)
+
       sales_invoice = order.create_avatax_sales_invoice!({
         transaction_id:        result[:transaction_id],
         doc_id:                result[:doc_id],
@@ -55,8 +57,6 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
         pre_tax_total:         result[:total_amount],
         additional_tax_total:  result[:total_tax],
       })
-
-      SpreeAvatax::SalesShared.update_taxes(order, tax_line_data)
 
       sales_invoice
     rescue Exception => e

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -99,6 +99,18 @@ module SpreeAvatax::SalesShared
     def reset_tax_attributes(order)
       return if order.completed?
 
+      # Delete the avatax_sales_invoice to avoid accidentally committing it
+      # later.
+      if invoice = order.avatax_sales_invoice
+        if invoice.committed_at
+          raise SpreeAvatax::SalesInvoice::AlreadyCommittedError.new(
+            "Tried to clear tax attributes for already-committed order #{order.number}"
+          )
+        else
+          invoice.destroy!
+        end
+      end
+
       destroyed_adjustments = order.all_adjustments.tax.destroy_all
       return if destroyed_adjustments.empty?
 

--- a/spec/models/spree_avatax/sales_invoice_spec.rb
+++ b/spec/models/spree_avatax/sales_invoice_spec.rb
@@ -331,6 +331,22 @@ describe SpreeAvatax::SalesInvoice do
         }.to_not change { SpreeAvatax::SalesInvoice.count }
       end
     end
+
+    context 'when an error occurs during tax updating' do
+      it 'does not create a SalesInvoice record' do
+        error = StandardError.new
+
+        expect(SpreeAvatax::SalesShared)
+          .to receive(:update_taxes)
+          .and_raise(error)
+
+        expect {
+          expect { subject }.to raise_error(error)
+        }.to_not change {
+          SpreeAvatax::SalesInvoice.count
+        }
+      end
+    end
   end
 
   describe '.commit' do

--- a/spec/models/spree_avatax/sales_shared_spec.rb
+++ b/spec/models/spree_avatax/sales_shared_spec.rb
@@ -58,5 +58,28 @@ describe SpreeAvatax::SalesShared do
       expect(line_item.reload.pre_tax_amount).to eq(2 * 3)
       expect(shipment.reload.pre_tax_amount).to eq(5)
     end
+
+    context 'when a SalesInvoice record is present' do
+      let!(:sales_invoice) { create(:avatax_sales_invoice, order: order) }
+
+      it 'deletes the SalesInvoice record if present' do
+        subject
+        expect(order.reload.avatax_sales_invoice).to eq(nil)
+      end
+
+      context 'when the SalesInvoice is committed' do
+        before do
+          sales_invoice.update!(committed_at: Time.now)
+        end
+
+        it 'raises without clearing anything' do
+          expect {
+            subject
+          }.to raise_error(SpreeAvatax::SalesInvoice::AlreadyCommittedError)
+
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Otherwise it's possible for this to happen:

- Get the order into the "confirm" state with a valid invoice
- Move the order backward into a prior state
- Move to the confirm state but fail to generate a new invoice (e.g.
during an Avatax outage)
- Complete the order and inadvertently commit an invalid invoice

Also: Only create a SalesInvoice after we successfully apply the tax
adjustments.