### PR TITLE
Use `prepend` instead of `alias_method_chain`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ env:
   matrix:
     - SOLIDUS_BRANCH=v1.1   DB=mysql
     - SOLIDUS_BRANCH=v1.2   DB=mysql
-    - SOLIDUS_BRANCH=master DB=mysql
     - SOLIDUS_BRANCH=v1.1   DB=postgres
     - SOLIDUS_BRANCH=v1.2   DB=postgres
-    - SOLIDUS_BRANCH=master DB=postgres
 script:
   - bundle exec rake test_app
   - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'v1.2')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise", "~> 1.0"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Solidus Avatax
 ===========
 
+[![Build Status](https://travis-ci.org/solidusio/solidus_avatax.svg?branch=master)](https://travis-ci.org/solidusio/solidus_avatax)
+ 
 Avatax integration with Solidus.
 
 Installation

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -1,26 +1,25 @@
 Spree::OrderContents.class_eval do
-  def add_with_avatax(*args)
-    add_without_avatax(*args).tap do
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
+  prepend Module.new do
+    def add(*args)
+      super.tap do
+        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+      end
+    end
+
+    def remove(*args)
+      super.tap do
+        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+      end
+    end
+
+
+    def update_cart(params)
+      if super
+        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+        true
+      else
+        false
+      end
     end
   end
-
-  def remove_with_avatax(*args)
-    remove_without_avatax(*args).tap do
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
-    end
-  end
-
-  def update_cart_with_avatax(params)
-    if update_cart_without_avatax(params)
-      SpreeAvatax::SalesShared.reset_tax_attributes(order)
-      true
-    else
-      false
-    end
-  end
-
-  alias_method_chain :update_cart, :avatax
-  alias_method_chain :add, :avatax
-  alias_method_chain :remove, :avatax
 end

--- a/app/models/spree/promotion_handler/coupon_decorator.rb
+++ b/app/models/spree/promotion_handler/coupon_decorator.rb
@@ -1,11 +1,11 @@
 Spree::PromotionHandler::Coupon.class_eval do
-  def apply_with_avatax
-    apply_without_avatax.tap do
-      if successful?
-        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+  prepend Module.new do
+    def apply
+      super.tap do
+        if successful?
+          SpreeAvatax::SalesShared.reset_tax_attributes(order)
+        end
       end
     end
   end
-
-  alias_method_chain :apply, :avatax
 end

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -1,0 +1,9 @@
+Spree::Tax::OrderAdjuster.class_eval do
+  def adjust_with_avatax!
+    # do nothing. we hook in in our own ways.
+    # TODO: See if we can make OrderAdjuster pluggable and workable for what we
+    # need to do.
+  end
+
+  alias_method_chain :adjust!, :avatax
+end

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -1,9 +1,9 @@
 Spree::Tax::OrderAdjuster.class_eval do
-  def adjust_with_avatax!
-    # do nothing. we hook in in our own ways.
-    # TODO: See if we can make OrderAdjuster pluggable and workable for what we
-    # need to do.
+  prepend Module.new do
+    def adjust!
+      # do nothing. we hook in in our own ways.
+      # TODO: See if we can make OrderAdjuster pluggable and workable for what we
+      # need to do.
+    end
   end
-
-  alias_method_chain :adjust!, :avatax
 end

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -24,11 +24,6 @@ Spree::TaxRate.class_eval do
     raise SpreeAvatax::TaxRateInvalidOperation.new("Spree::TaxRate#adjust should never be called when Avatax is present")
   end
 
-  def compute_amount(item)
-    # Avatax tax adjustments should always be finalized so Spree should never attempt to call this code
-    raise SpreeAvatax::TaxRateInvalidOperation.new("Spree::TaxRate#compute_amount should never be called when Avatax is present")
-  end
-
   private
 
   def avatax_there_can_be_only_one

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -12,12 +12,6 @@ Spree::TaxRate.class_eval do
       # do nothing.  we'll take care of this ourselves at different points via the various hooks we have in place
     end
 
-    def store_pre_tax_amount
-      # do nothing.  this is only for "included" and we don't support included tax.
-      # also, we perform calculations at a different time.
-      # this should never be called anyway because only TaxRate.adjust calls it, but we override it just to be safe.
-    end
-
     # require exactly one tax rate.  if that's not true then alert ourselves and carry on as best we can
     def avatax_the_one_rate
       rates = all.to_a

--- a/app/models/spree_avatax/calculator.rb
+++ b/app/models/spree_avatax/calculator.rb
@@ -14,7 +14,11 @@ class SpreeAvatax::Calculator < Spree::Calculator
   end
 
   def compute(computable)
-    raise DoNotUseCompute.new("The avatax calculator should never use #compute")
+    if computable.is_a?(Spree::ShippingRate)
+      0
+    else
+      raise DoNotUseCompute.new("The avatax calculator should never use #compute")
+    end
   end
 
   def compute_shipping_rate(shipping_rate)

--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -169,7 +169,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
           itemcode:            return_item.inventory_unit.line_item.variant.sku,
           taxcode:             return_item.inventory_unit.line_item.tax_category.tax_code,
           qty:                 1,
-          amount:              -return_item.pre_tax_amount,
+          amount:              -return_item.amount,
           origincodeline:      DESTINATION_CODE, # We don't really send the correct value here
           destinationcodeline: DESTINATION_CODE,
 

--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -30,11 +30,6 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
 
       return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
-      taxable_records = order.line_items + order.shipments
-      taxable_records.each do |taxable_record|
-        taxable_record.update_column(:pre_tax_amount, taxable_record.discounted_amount.round(2))
-      end
-
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)
       # run this immediately to ensure that everything matches up before modifying the database
       tax_line_data = SpreeAvatax::SalesShared.build_tax_line_data(order, result)

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -31,8 +31,6 @@ module SpreeAvatax::SalesShared
       tax_line_data.each do |data|
         record, tax_line = data[:record], data[:tax_line]
 
-        record.update_column(:pre_tax_amount, record.discounted_amount.round(2))
-
         tax = BigDecimal.new(tax_line[:tax]).abs
 
         record.adjustments.tax.create!({
@@ -119,7 +117,6 @@ module SpreeAvatax::SalesShared
         taxable_record.update_attributes!({
           additional_tax_total: 0,
           adjustment_total: 0,
-          pre_tax_amount: taxable_record.discounted_amount.round(2),
           included_tax_total: 0,
         })
 

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -73,7 +73,7 @@ module SpreeAvatax::SalesShared
         if data[avatax_id]
           data[avatax_id][:tax_line] = tax_line
         else
-          raise InvalidApiResponse.new("Couldn't find #{avatax_id.inspect}")
+          raise InvalidApiResponse.new("Couldn't find #{avatax_id.inspect} from avatax response in known ids #{data.keys.inspect}")
         end
       end
 

--- a/lib/spree_avatax/factories.rb
+++ b/lib/spree_avatax/factories.rb
@@ -9,8 +9,8 @@ FactoryGirl.define do
     doc_id { generate(:doc_id) }
     doc_code { order.number }
     doc_date { order.completed_at.try(:to_date) || 1.day.ago }
-    pre_tax_total { order.line_items.sum(:pre_tax_amount) }
-    additional_tax_total { order.line_items.sum(:additional_tax_total) }
+    pre_tax_total { order.total - order.additional_tax_total }
+    additional_tax_total { order.additional_tax_total }
   end
 
   factory :return_invoice, class: SpreeAvatax::ReturnInvoice do
@@ -19,7 +19,7 @@ FactoryGirl.define do
     doc_id { generate(:doc_id) }
     doc_code { reimbursement.number }
     doc_date { reimbursement.order.avatax_invoice_at.try(:to_date) || reimbursement.order.completed_at.to_date }
-    pre_tax_total { reimbursement.return_items.sum(:pre_tax_amount) }
+    pre_tax_total { reimbursement.return_items.sum(:amount) }
     additional_tax_total { reimbursement.return_items.sum(:additional_tax_total) }
   end
 

--- a/solidus_avatax.gemspec
+++ b/solidus_avatax.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = "solidus_avatax"
-  s.version     = "1.0.0"
+  s.version     = "1.1.0"
   s.summary     = "Avatax extension for Solidus"
   s.description = "Solidus extension to retrieve tax rates via Avalara's SOAP API."
   s.required_ruby_version = ">= 2.1"

--- a/solidus_avatax.gemspec
+++ b/solidus_avatax.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
   s.requirements << "none"
 
-  s.add_dependency "solidus_core", ">= 1.1.0.pre", "< 1.3"
+  s.add_dependency "solidus_core", ">= 1.3.0.alpha", "< 1.4"
   s.add_dependency "hashie",      "~> 2.l.5"
   s.add_dependency "multi_json"
   s.add_dependency "Avatax_TaxService", "~> 2.0.0"

--- a/spec/features/store_credits_spec.rb
+++ b/spec/features/store_credits_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Taxes with Store Credits" do
   let(:user) { FactoryGirl.create(:user, password: "Alderaan") }
+  let!(:store) { create(:store, default: true) }
 
   before do
     # Set up Avatax (just in case we don't have a cassette)

--- a/spec/features/store_credits_spec.rb
+++ b/spec/features/store_credits_spec.rb
@@ -54,12 +54,24 @@ RSpec.describe "Taxes with Store Credits" do
         fill_in "Phone", with: "(555) 555-5555"
       end
       click_on "Save and Continue"
-
     end
 
     it "adjusts the credits to cover taxes" do
       # Use a cassette so that we don't hit the Avatax API all of the time.
       VCR.use_cassette("taxes_with_store_credits") do
+        expect(SpreeAvatax::SalesShared).to(
+          receive(:avatax_id).
+            with(an_instance_of(Spree::LineItem)).
+            at_least(:once).
+            and_return('Spree::LineItem-1')
+        )
+        expect(SpreeAvatax::SalesShared).to(
+          receive(:avatax_id).
+            with(an_instance_of(Spree::Shipment)).
+            at_least(:once).
+            and_return('Spree::Shipment-1')
+        )
+
         click_on "Save and Continue"
       end
 

--- a/spec/features/tax_calculation_spec.rb
+++ b/spec/features/tax_calculation_spec.rb
@@ -5,6 +5,7 @@ describe "Tax Calculation" do
   let(:address) { create(:address, address1: "35 Crosby St", city: "New York", zipcode: 10013) }
   let(:line_item_1) { order.line_items.first }
   let(:line_item_2) { order.line_items.last }
+  let(:shipment) { order.shipments.first }
 
   before do
     # Set up Avatax (just in case we don't have a cassette)
@@ -14,6 +15,25 @@ describe "Tax Calculation" do
     SpreeAvatax::Config.company_code = ENV["AVATAX_COMPANY_CODE"]
 
     order.line_items.first.product.tax_category.tax_rates << Spree::TaxRate.first
+
+    expect(SpreeAvatax::SalesShared).to(
+      receive(:avatax_id).
+        with(line_item_1).
+        at_least(:once).
+        and_return('Spree::LineItem-1')
+    )
+    expect(SpreeAvatax::SalesShared).to(
+      receive(:avatax_id).
+        with(line_item_2).
+        at_least(:once).
+        and_return('Spree::LineItem-2')
+    )
+    expect(SpreeAvatax::SalesShared).to(
+      receive(:avatax_id).
+        with(shipment).
+        at_least(:once).
+        and_return('Spree::Shipment-1')
+    )
   end
 
   context "without discounts" do

--- a/spec/models/spree/shipping_rate_spec.rb
+++ b/spec/models/spree/shipping_rate_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Spree::ShippingRate do
-  subject do
-    shipping_rate.calculate_tax_amount
-  end
-
   let(:shipping_rate) do
     shipment.shipping_rates.create!({
       tax_rate:        Spree::TaxRate.first,
@@ -17,7 +13,7 @@ describe Spree::ShippingRate do
   let(:shipment) { create(:shipment) }
   let(:shipping_method) { create(:shipping_method) }
 
-  it 'foo' do
-    expect(subject).to eq 0
+  it 'calculates shipping rate taxes as 0' do
+    expect(shipping_rate.calculate_tax_amount).to eq 0
   end
 end

--- a/spec/models/spree/tax_rate_spec.rb
+++ b/spec/models/spree/tax_rate_spec.rb
@@ -29,12 +29,4 @@ describe Spree::TaxRate do
       }.to raise_error(SpreeAvatax::TaxRateInvalidOperation)
     end
   end
-
-  describe '#compute_amount' do
-    it 'raises TaxRateInvalidOperation' do
-      expect {
-        tax_rate.compute_amount(nil)
-      }.to raise_error(SpreeAvatax::TaxRateInvalidOperation)
-    end
-  end
 end

--- a/spec/models/spree_avatax/return_invoice_spec.rb
+++ b/spec/models/spree_avatax/return_invoice_spec.rb
@@ -38,7 +38,7 @@ describe SpreeAvatax::ReturnInvoice do
             itemcode:            return_item.inventory_unit.line_item.variant.sku,
             taxcode:             return_item.inventory_unit.line_item.tax_category.tax_code,
             qty:                 1,
-            amount:              -return_item.pre_tax_amount,
+            amount:              -return_item.amount,
             origincodeline:      SpreeAvatax::ReturnInvoice::DESTINATION_CODE,
             destinationcodeline: SpreeAvatax::ReturnInvoice::DESTINATION_CODE,
 

--- a/spec/models/spree_avatax/sales_invoice_spec.rb
+++ b/spec/models/spree_avatax/sales_invoice_spec.rb
@@ -200,19 +200,7 @@ describe SpreeAvatax::SalesInvoice do
           .to receive(:get_tax)
           .and_raise(error)
 
-        order.line_items.update_all(pre_tax_amount: 0)
         order.reload
-      end
-
-      it 'sets the pre_tax_amount on each line item in the order' do
-        expect{ subject }.to raise_error(error)
-        expect(order.line_items.first.pre_tax_amount.to_f).to equal(order.line_items.first.discounted_amount.to_f)
-        expect(order.line_items.last.pre_tax_amount.to_f).to equal(order.line_items.last.discounted_amount.to_f)
-      end
-
-      it 'sets the pre_tax_amount on each shipment in the order' do
-        expect{ subject }.to raise_error(error)
-        expect(order.shipments.first.pre_tax_amount.to_f).to equal(order.shipments.first.discounted_amount.to_f)
       end
 
       context 'when an error_handler is not defined' do

--- a/spec/models/spree_avatax/sales_shared_spec.rb
+++ b/spec/models/spree_avatax/sales_shared_spec.rb
@@ -32,7 +32,6 @@ describe SpreeAvatax::SalesShared do
       line_item.update_attributes!({
         additional_tax_total: 1,
         adjustment_total: 1,
-        pre_tax_amount: 1,
         included_tax_total: 1,
       })
     end
@@ -51,12 +50,6 @@ describe SpreeAvatax::SalesShared do
     it 'should remove all eligible tax adjustments' do
       subject
       expect(line_item.adjustments.tax.count).to eq 0
-    end
-
-    it 'sets pre_tax_amount to discounted_amount' do
-      subject
-      expect(line_item.reload.pre_tax_amount).to eq(2 * 3)
-      expect(shipment.reload.pre_tax_amount).to eq(5)
     end
 
     context 'when a SalesInvoice record is present' do


### PR DESCRIPTION
* `alias_method_chain` causes errors when using background jobs to process orders with sidekiq (see https://github.com/mperham/sidekiq/issues/2139)