### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/app/models/spree/promotion_handler/coupon_decorator.rb
+++ b/app/models/spree/promotion_handler/coupon_decorator.rb
@@ -1,11 +1,15 @@
-Spree::PromotionHandler::Coupon.class_eval do
-  def apply_with_avatax
-    apply_without_avatax.tap do
-      if successful?
-        SpreeAvatax::SalesShared.reset_tax_attributes(order)
+module Solidus
+  module Avatax
+    module PromotionHandler
+      def apply
+        super.tap do
+          if successful?
+            SpreeAvatax::SalesShared.reset_tax_attributes(order)
+          end
+        end
       end
     end
   end
-
-  alias_method_chain :apply, :avatax
 end
+
+Spree::PromotionHandler::Coupon.send(:prepend, Solidus::Avatax::PromotionHandler)

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -1,9 +1,9 @@
-Spree::Tax::OrderAdjuster.class_eval do
-  def adjust_with_avatax!
+module Solidus::Avatax::OrderAdjuster
+  def adjust!
     # do nothing. we hook in in our own ways.
     # TODO: See if we can make OrderAdjuster pluggable and workable for what we
     # need to do.
   end
-
-  alias_method_chain :adjust!, :avatax
 end
+
+Spree::Tax::OrderAdjuster.send(:prepend, Solidus::Avatax::OrderAdjuster)

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -7,7 +7,7 @@ describe Spree::OrderContents do
   describe 'add_with_avatax' do
     let(:variant) { create :variant }
 
-    subject { order_contents.add_with_avatax(variant) }
+    subject { order_contents.add(variant) }
 
     it 'clears tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)
@@ -16,7 +16,7 @@ describe Spree::OrderContents do
   end
 
   describe 'remove_with_avatax' do
-    subject { order_contents.remove_with_avatax(order.line_items.first.variant) }
+    subject { order_contents.remove(order.line_items.first.variant) }
 
     it 'recomputes tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)
@@ -25,7 +25,7 @@ describe Spree::OrderContents do
   end
 
   describe 'update_cart_with_avatax' do
-    subject { order_contents.update_cart_with_avatax({}) }
+    subject { order_contents.update_cart({}) }
 
     it 'recomputes tax' do
       expect(SpreeAvatax::SalesShared).to receive(:reset_tax_attributes).with(order)


### PR DESCRIPTION
alias_method_chain is going to be deprecated.
This fix convert the decorators into a module and prepend it to the class


cc #27 @djones